### PR TITLE
fix the miss overwrite step

### DIFF
--- a/hw1/cs285/infrastructure/rl_trainer.py
+++ b/hw1/cs285/infrastructure/rl_trainer.py
@@ -45,6 +45,7 @@ class RL_Trainer(object):
 
         # Maximum length for episodes
         self.params['ep_len'] = self.params['ep_len'] or self.env.spec.max_episode_steps
+        global MAX_VIDEO_LEN
         MAX_VIDEO_LEN = self.params['ep_len']
 
         # Is this env continuous, or self.discrete?


### PR DESCRIPTION
```python
MAX_VIDEO_LEN = 40  # we overwrite this in the code below
```
In python, it needs to 
`global MAX_VIDEO_LEN`
Then replace the value

But it still have problems if the `MAX_VIDEO_LEN` be so large, so I recommend ep_len just smaller than 1000